### PR TITLE
Fix ReferenceError for getTickRate

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -1,5 +1,5 @@
 module.exports = function(config){
-  let pubsub = config.common.storage.pubsub
+  let { env, pubsub } = config.common.storage
   if(config.cli) {
     config.cli.on('cliSandbox', function(sandbox) {
       sandbox.setTickRate = function(value) {


### PR DESCRIPTION
This fixes the `ReferenceError: env is not defined` when calling `getTickRate()` from the screeps cli.